### PR TITLE
[#6] Support Proxies That Set Additional Cookies

### DIFF
--- a/intray-api/src/Intray/API.hs
+++ b/intray-api/src/Intray/API.hs
@@ -18,8 +18,6 @@ import Import
 
 import Data.UUID.Typed
 
-import Web.Cookie
-
 import Servant.API
 import Servant.API.Generic
 import Servant.Auth.Docs ()
@@ -70,7 +68,7 @@ data IntrayPublicSite route =
 type PostRegister = "register" :> ReqBody '[ JSON] Registration :> Post '[ JSON] NoContent
 
 type PostLogin
-   = "login" :> ReqBody '[ JSON] LoginForm :> PostNoContent '[ JSON] (Headers '[ Header "Set-Cookie" SetCookie, Header "Set-Cookie" SetCookie] NoContent)
+   = "login" :> ReqBody '[ JSON] LoginForm :> PostNoContent '[ JSON] (Headers '[ Header "Set-Cookie" Text] NoContent)
 
 type GetDocs = Get '[ HTML] GetDocsResponse
 

--- a/intray-client/src/Intray/Client.hs
+++ b/intray-client/src/Intray/Client.hs
@@ -19,7 +19,6 @@ import qualified Data.UUID.Typed
 import Servant.API
 import Servant.API.Flatten
 import Servant.Auth.Client
-import Servant.Auth.Server
 import Servant.Client
 
 import Intray.API
@@ -44,9 +43,7 @@ clientGetAccessKeys :: Token -> ClientM [AccessKeyInfo]
 clientDeleteAccessKey :: Token -> AccessKeyUUID -> ClientM NoContent
 clientGetPermissions :: Token -> ClientM (Set Permission)
 clientPostRegister :: Registration -> ClientM NoContent
-clientPostLogin ::
-     LoginForm
-  -> ClientM (Headers '[ Header "Set-Cookie" SetCookie, Header "Set-Cookie" SetCookie] NoContent)
+clientPostLogin :: LoginForm -> ClientM (Headers '[ Header "Set-Cookie" Text] NoContent)
 clientGetDocs :: ClientM GetDocsResponse
 clientGetPricing :: ClientM (Maybe Pricing)
 clientAdminGetStats :: Token -> ClientM AdminStats

--- a/intray-web-server/src/Intray/Web/Server/Foundation.hs
+++ b/intray-web-server/src/Intray/Web/Server/Foundation.hs
@@ -21,6 +21,7 @@ import Import
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
+import Data.Text.Encoding (encodeUtf8)
 
 import Control.Concurrent
 
@@ -318,7 +319,7 @@ login form = do
             addMessage "error" "Unable to login"
             redirect $ AuthR LoginR
           else sendResponseStatus Http.status500 $ show resp
-    Right (Headers NoContent (HCons _ (HCons sessionHeader HNil))) ->
+    Right (Headers NoContent (HCons sessionHeader HNil)) ->
       case sessionHeader of
         Header session -> recordLoginToken (loginFormUsername form) session
         _ ->
@@ -340,9 +341,9 @@ lookupToginToken un = do
   tokenMap <- liftIO $ readMVar tokenMapVar
   pure $ HM.lookup un tokenMap
 
-recordLoginToken :: Username -> SetCookie -> Handler ()
+recordLoginToken :: Username -> Text -> Handler ()
 recordLoginToken un session = do
-  let token = Token $ setCookieValue session
+  let token = Token $ setCookieValue $ parseSetCookie $ encodeUtf8 session
   tokenMapVar <- getsYesod appLoginTokens
   liftIO $ modifyMVar_ tokenMapVar $ pure . HM.insert un token
   whenPersistLogins storeLogins


### PR DESCRIPTION
This fixes the CLI client & I'm currently building this to test the `intray-server` changes. I don't use the web-server, so logging in via that should be tested as well.

Similar changes are needed to fix `smos-server` and `tickler-server`.

Commit message follows:

---

Add support for using the CLI client with proxied servers that append
their own cookies to the `Set-Cookie` header returned by the `PostLogin`
API route.

For example, servers proxied behind CloudFlare will get a __cfuid cookie
appended to the Set-Cookie header. Previously, the client would
incorrectly save the __cfuid cookie to the session.cookie file. We
prevent this by having the client's PostLogin handler parse the Cookies
itself, locate the correct `JWT-Cookie` cookie, and explicitly save
that cookie, instead relying on Servant's SetCookie parsing which simply
parses the first cookie it sees.

We also collapse the double "Set-Cookie" Header in the PostLogin API
route since it is no longer necessary.

Closes #6 