### PR TITLE
On no input, stop review

### DIFF
--- a/intray-cli/src/Intray/Cli/Commands/Review.hs
+++ b/intray-cli/src/Intray/Cli/Commands/Review.hs
@@ -39,4 +39,5 @@ review = do
         "Y" -> cont
         "n" -> stop
         "N" -> stop
+        "" -> stop
         _ -> review


### PR DESCRIPTION
The `[yN]` prompt seems to suggest `n` is the default action. However, if you submit the default action, i.e. just hit return, the review prompt comes back up. I believe the default behavior should be to stop the review.

I submitted the most trivial addition to the code but it could be made more robust to the user input by trimming space characters from `res`. Let me know if you would like me to make this change as well. 