### PR TITLE
Add static home manager modules

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -124,9 +124,18 @@
       nixosModules.${system} = {
         serviceNotifications = import ./nix/service-notifications.nix { inherit (pkgsMusl.intrayRelease) notification; };
       };
-      homeManagerModules.${system}.default = import ./nix/home-manager-module.nix {
-        inherit (pkgsMusl.intrayReleasePackages) intray-cli;
-        inherit (pkgsMusl.haskellPackages) opt-env-conf;
+      homeManagerModules.${system} = {
+        default =
+          builtins.trace "Note: use 'static' to get statically linked intray" (
+            import ./nix/home-manager-module.nix {
+              inherit (pkgs.intrayReleasePackages) intray-cli;
+              inherit (pkgs.haskellPackages) opt-env-conf;
+            }
+          );
+        static = import ./nix/home-manager-module.nix {
+          inherit (pkgsMusl.intrayReleasePackages) intray-cli;
+          inherit (pkgsMusl.haskellPackages) opt-env-conf;
+        };
       };
       nix-ci = {
         auto-update = {

--- a/flake.nix
+++ b/flake.nix
@@ -125,14 +125,11 @@
         serviceNotifications = import ./nix/service-notifications.nix { inherit (pkgsMusl.intrayRelease) notification; };
       };
       homeManagerModules.${system} = {
-        default =
-          builtins.trace "Note: use 'static' to get statically linked intray" (
-            import ./nix/home-manager-module.nix {
-              inherit (pkgs.intrayReleasePackages) intray-cli;
-              inherit (pkgs.haskellPackages) opt-env-conf;
-            }
-          );
-        static = import ./nix/home-manager-module.nix {
+        dynamic = import ./nix/home-manager-module.nix {
+          inherit (pkgs.intrayReleasePackages) intray-cli;
+          inherit (pkgs.haskellPackages) opt-env-conf;
+        };
+        default = import ./nix/home-manager-module.nix {
           inherit (pkgsMusl.intrayReleasePackages) intray-cli;
           inherit (pkgsMusl.haskellPackages) opt-env-conf;
         };


### PR DESCRIPTION
Unsure how you want to do the roll-out here.

Here, I just switch `default` to the non-statically linked one and add a new `static` configuration. With a `builtins.trace` explaining that you can use `static` instead. I suppose that can be removed after some time.

When I use this for my own home manager config,

```
  inputs = {
    intray = {
      type = "github";
      owner = "chiroptical";
      repo = "intray";
      ref = "chiroptical/add-static-home-manager-modules";
    };
  };
```

```
➤ home-manager switch
trace: Note: use 'static' to get statically linked intray    <---- note this line!
Starting Home Manager activation
Activating checkFilesChanged
Activating checkLinkTargets
Activating writeBoundary
Activating installPackages
replacing old 'home-manager-path'
installing 'home-manager-path'
Activating linkGeneration
Cleaning up orphan links from /home/barry
No change so reusing latest profile generation 135
Creating home file links in /home/barry
Activating onFilesChange
Activating reloadSystemd
trace: Note: use 'static' to get statically linked intray

There are 162 unread and relevant news items.
Read them by running the command "home-manager news".
```